### PR TITLE
Add JSCS and JSHint files

### DIFF
--- a/jscsrc
+++ b/jscsrc
@@ -1,0 +1,111 @@
+{
+  // http://jscs.info/rule/disallowTrailingWhitespace.html
+  "disallowTrailingWhitespace": true,
+
+  // http://jscs.info/rule/disallowMultipleSpaces.html
+  "disallowMultipleSpaces": true,
+
+  // http://jscs.info/rule/requireCommaBeforeLineBreak.html
+  "requireCommaBeforeLineBreak": true,
+
+  // http://jscs.info/rule/requireLineBreakAfterVariableAssignment.html
+  "requireLineBreakAfterVariableAssignment": true,
+
+  // http://jscs.info/rule/requireMultipleVarDecl.html
+  "requireMultipleVarDecl": true,
+
+  // http://jscs.info/rule/disallowSpaceAfterPrefixUnaryOperators.html
+  "disallowSpaceAfterPrefixUnaryOperators": [ "++", "--", "!" ],
+
+  // http://jscs.info/rule/requireSpaceAfterKeywords.html
+  "requireSpaceAfterKeywords": [
+    "do",
+    "for",
+    "if",
+    "else",
+    "switch",
+    "case",
+    "try",
+    "catch",
+    "void",
+    "while",
+    "with",
+    "return",
+    "typeof",
+    "function"
+  ],
+
+  // http://jscs.info/rule/requireSpaceBeforeBlockStatements.html
+  "requireSpaceBeforeBlockStatements": 1,
+
+  // http://jscs.info/rule/requireSpaceBetweenArguments.html
+  "requireSpaceBetweenArguments": true,
+
+  // http://jscs.info/rule/requireSpaceAfterBinaryOperators.html
+  "requireSpaceAfterBinaryOperators": [ "=", ",", "+", "-", "/", "*", "==", "===", "!=", "!==" ],
+
+  // http://jscs.info/rule/requireSpaceBeforeBinaryOperators.html
+  "requireSpaceBeforeBinaryOperators": [ "=", "+", "-", "/", "*", "===", "!==" ],
+
+  // http://jscs.info/rule/requireSpaceBeforeObjectValues.html
+  "requireSpaceBeforeObjectValues": true,
+
+  // http://jscs.info/rule/requireSpaceAfterLineComment.html
+  "requireSpaceAfterLineComment": true,
+
+  // http://jscs.info/rule/requireSpaceBeforeKeywords.html
+  "requireSpaceBeforeKeywords": [ "else", "while", "catch" ],
+
+  // http://jscs.info/rule/requireSpacesInForStatement.html
+  "requireSpacesInForStatement": true,
+
+  // http://jscs.info/rule/requireCamelCaseOrUpperCaseIdentifiers.html
+  "requireCamelCaseOrUpperCaseIdentifiers": true,
+
+  // http://jscs.info/rule/requireSemicolons.html
+  "requireSemicolons": true,
+
+  // http://jscs.info/rule/requireCurlyBraces.html
+  "requireCurlyBraces": true,
+
+  // http://jscs.info/rule/requireSpacesInAnonymousFunctionExpression.html
+  "requireSpacesInAnonymousFunctionExpression": {
+    "beforeOpeningRoundBrace": true,
+    "beforeOpeningCurlyBrace": true
+  },
+
+  // http://jscs.info/rule/requireSpacesInNamedFunctionExpression.html
+  "requireSpacesInNamedFunctionExpression": {
+    "beforeOpeningRoundBrace": true,
+    "beforeOpeningCurlyBrace": true
+  },
+
+  // http://jscs.info/rule/requireSpacesInConditionalExpression.html
+  "requireSpacesInConditionalExpression": {
+    "afterTest": true,
+    "beforeConsequent": true,
+    "afterConsequent": true,
+    "beforeAlternate": true
+  },
+
+  // http://jscs.info/rule/disallowSpacesInCallExpression.html
+  "disallowSpacesInCallExpression": true,
+
+  // http://jscs.info/rule/requireAnonymousFunctions.html
+  "requireAnonymousFunctions": true,
+
+  // http://jscs.info/rule/disallowEmptyBlocks.html
+  "disallowEmptyBlocks": true,
+
+  // http://jscs.info/rule/disallowMixedSpacesAndTabs.html
+  "disallowMixedSpacesAndTabs": true,
+
+  // http://jscs.info/rule/disallowNewlineBeforeBlockStatements.html
+  "disallowNewlineBeforeBlockStatements": true,
+
+  // http://jscs.info/rule/validateQuoteMarks.html
+  "validateQuoteMarks": {
+    "mark": "'",
+    "escape": true
+  }
+}

--- a/jshintrc
+++ b/jshintrc
@@ -1,0 +1,5 @@
+{
+  "eqeqeq": true,
+  "laxbreak": true,
+  "expr": true
+}


### PR DESCRIPTION
This commit contains the start of the configuration to check for
Meteor Style Guide's JS style rules. Unfortunately, JSCS could not
cover all of the rules needed, but it covers the majority of the
rules. JSHint covers a couple of syntax rules needed.
